### PR TITLE
tokens can cause STDERR PHP Notice

### DIFF
--- a/src/ZenifyCodingStandard/Sniffs/ControlStructures/WeakTypesComparisonsWithExplanationSniff.php
+++ b/src/ZenifyCodingStandard/Sniffs/ControlStructures/WeakTypesComparisonsWithExplanationSniff.php
@@ -59,7 +59,7 @@ class WeakTypesComparisonsWithExplanationSniff implements PHP_CodeSniffer_Sniff
 			}
 			$currentPosition++;
 
-		} while ($tokens[$currentPosition]['content'] !== PHP_EOL);
+		} while (isset($tokens[$currentPosition]) && $tokens[$currentPosition]['content'] !== PHP_EOL);
 
 		if ( ! $hasComment) {
 			$error = '"%s" should be used instead of "%s", or commented with its purpose';


### PR DESCRIPTION
In PHPStorm can non exist token cause PHP Notice which break Code Sniffer tool and PHPStorm print error to log:

> 2014-12-16 08:44:26,724 [  46644]   INFO - lity.QualityToolProcessHandler - STDERR: PHP Notice:  Undefined offset: 79309 in X:\SomeProjectName\vendor\zenify\coding-standard\src\ZenifyCodingStandard\Sniffs\ControlStructures\WeakTypesComparisonsWithExplanationSniff.php on line 54
> 
> 2014-12-16 08:44:26,724 [  46644]   INFO - lity.QualityToolProcessHandler - STDERR: PHP Notice:  Undefined offset: 79309 in X:\SomeProjectName\vendor\zenify\coding-standard\src\ZenifyCodingStandard\Sniffs\ControlStructures\WeakTypesComparisonsWithExplanationSniff.php on line 55
> 
> 2014-12-16 08:44:26,724 [  46644]   INFO - lity.QualityToolProcessHandler - STDERR: PHP Notice:  Undefined offset: 79310 in X:\SomeProjectName\vendor\zenify\coding-standard\src\ZenifyCodingStandard\Sniffs\ControlStructures\WeakTypesComparisonsWithExplanationSniff.php on line 62*
